### PR TITLE
Removing the master-slave language

### DIFF
--- a/smarthome/src/MQTT_Server_Client/mqttpubclient.py
+++ b/smarthome/src/MQTT_Server_Client/mqttpubclient.py
@@ -49,7 +49,7 @@ while 1==1:
 #读取sqlite数据库data
     cursor = c.execute("SELECT intent, slots from myhome_commands")
     for row in cursor:
-       payload = '{"intent":"%s","slots":"%s","slaveID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
+       payload = '{"intent":"%s","slots":"%s","subordinateID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
        %(row[0], row[1])
 
 #判断读取到的字符串是否有变换（语音控制的输出）
@@ -70,7 +70,7 @@ while 1==1:
          on_mqtt_connect()
          on_publish("0/node/commands/control", payload, 1)
 
-#       payload = '{"intent":"%s","slots":"%s","slaveID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
+#       payload = '{"intent":"%s","slots":"%s","subordinateID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
 #       %(row[0], row[1])
        print (payload)
 

--- a/smarthome/src/MQTT_Server_Client/mqttsubclient.py
+++ b/smarthome/src/MQTT_Server_Client/mqttsubclient.py
@@ -23,12 +23,12 @@ def on_message(client, userdata, msg):
     print ("Opened database successfulliy")
 
 #创建表
-#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , slaveId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
+#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , subordinateId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
 #    print ("create myhome_nodedata table success")
 #    conn.commit()
 
 #写入data
-    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,slaveId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (sline["time"],sline["localshortaddr"],sline["gateway_id"],sline["slaveId"],sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
+    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,subordinateId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (sline["time"],sline["localshortaddr"],sline["gateway_id"],sline["subordinateId"],sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
     conn.execute(sql)
     conn.commit()
     print ("Records created successfully insert into myhome_nodedata values")

--- a/smarthome/src/MQTT_Server_Client/mqttsubclient_nogateway.py
+++ b/smarthome/src/MQTT_Server_Client/mqttsubclient_nogateway.py
@@ -24,12 +24,12 @@ def on_message(client, userdata, msg):
     print ("Opened database successfulliy")
 
 #创建表
-#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , slaveId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
+#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , subordinateId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
 #    print ("create myhome_nodedata table success")
 #    conn.commit()
 
 #写入data
-    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,slaveId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (time.strftime('%Y-%m-%d/%H:%M:%S'),"F5A1","0","1",sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
+    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,subordinateId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (time.strftime('%Y-%m-%d/%H:%M:%S'),"F5A1","0","1",sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
     conn.execute(sql)
     conn.commit()
     print ("Records created successfully insert into myhome_nodedata values")

--- a/smarthome/src/RT_Data_Interaction/mqttpubclient.py
+++ b/smarthome/src/RT_Data_Interaction/mqttpubclient.py
@@ -49,7 +49,7 @@ while 1==1:
 #读取sqlite数据库data
     cursor = c.execute("SELECT intent, slots from myhome_commands")
     for row in cursor:
-       payload = '{"intent":"%s","slots":"%s","slaveID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
+       payload = '{"intent":"%s","slots":"%s","subordinateID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
        %(row[0], row[1])
 
 #判断读取到的字符串是否有变换（语音控制的输出）
@@ -70,7 +70,7 @@ while 1==1:
          on_mqtt_connect()
          on_publish("0/node/commands/control", payload, 1)
 
-#       payload = '{"intent":"%s","slots":"%s","slaveID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
+#       payload = '{"intent":"%s","slots":"%s","subordinateID":3,"control":1,"command_first_byte":1,"command_second_byte":2,"command_third_byte":3,"command_fourth_byte":4}' \
 #       %(row[0], row[1])
        print (payload)
 

--- a/smarthome/src/RT_Data_Interaction/mqttsubclient.py
+++ b/smarthome/src/RT_Data_Interaction/mqttsubclient.py
@@ -23,12 +23,12 @@ def on_message(client, userdata, msg):
     print ("Opened database successfulliy")
 
 #创建表
-#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , slaveId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
+#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , subordinateId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
 #    print ("create myhome_nodedata table success")
 #    conn.commit()
 
 #写入data
-    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,slaveId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (sline["time"],sline["localshortaddr"],sline["gateway_id"],sline["slaveId"],sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
+    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,subordinateId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (sline["time"],sline["localshortaddr"],sline["gateway_id"],sline["subordinateId"],sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
     conn.execute(sql)
     conn.commit()
     print ("Records created successfully insert into myhome_nodedata values")

--- a/smarthome/src/RT_Data_Interaction/mqttsubclient_nogateway.py
+++ b/smarthome/src/RT_Data_Interaction/mqttsubclient_nogateway.py
@@ -24,12 +24,12 @@ def on_message(client, userdata, msg):
     print ("Opened database successfulliy")
 
 #创建表
-#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , slaveId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
+#    c.execute('create table myhome_nodedata (id Integer primary key autoincrement , time Text , localshortaddr Text , gateway_id Text , subordinateId Text , humidity Integer , temperature Integer , light Integer , noise Integer , co2_simulation Integer , co2_binarization Integer)')
 #    print ("create myhome_nodedata table success")
 #    conn.commit()
 
 #写入data
-    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,slaveId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (time.strftime('%Y-%m-%d/%H:%M:%S'),"F5A1","0","1",sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
+    sql = "insert into myhome_nodedata(time,localshortaddr, gateway_id,subordinateId, humidity, temperature,light, noise, co2_simulation, co2_binarization)values('%s','%s','%s','%s',%f,%f,%f,%f,%f,%f)" % (time.strftime('%Y-%m-%d/%H:%M:%S'),"F5A1","0","1",sline["humidity"],sline["temperature"],sline["light"],sline["noise"],sline["co2_simulation"],sline["co2_binarization"])
     conn.execute(sql)
     conn.commit()
     print ("Records created successfully insert into myhome_nodedata values")

--- a/smarthome/src/RT_Data_Interaction/myhome/migrations/0001_initial.py
+++ b/smarthome/src/RT_Data_Interaction/myhome/migrations/0001_initial.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                 ('time', models.TextField(max_length=64)),
                 ('localshortaddr', models.TextField(max_length=64)),
                 ('gateway_id', models.TextField(max_length=64)),
-                ('slaveId', models.TextField(max_length=64)),
+                ('subordinateId', models.TextField(max_length=64)),
                 ('humidity', models.IntegerField(default=0)),
                 ('temperature', models.IntegerField(default=0)),
                 ('light', models.IntegerField(default=0)),

--- a/smarthome/src/RT_Data_Interaction/myhome/models.py
+++ b/smarthome/src/RT_Data_Interaction/myhome/models.py
@@ -6,7 +6,7 @@ class Nodedata(models.Model):
 	time = models.TextField(max_length = 64)
 	localshortaddr = models.TextField(max_length = 64)
 	gateway_id = models.TextField(max_length = 64)
-	slaveId = models.TextField(max_length = 64)
+	subordinateId = models.TextField(max_length = 64)
 	humidity = models.IntegerField(default = 0)
 	temperature = models.IntegerField(default = 0)
 	light = models.IntegerField(default = 0)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.